### PR TITLE
pprint was pprinting the wrong labels for files.

### DIFF
--- a/src/leiningen/bower.clj
+++ b/src/leiningen/bower.clj
@@ -50,9 +50,9 @@
   ([project & args]
      (environmental-consistency project)
      (cond (= ["pprint"] args)
-           (do (bower-debug project (bower-package-file project) project->bowerrc)
+           (do (bower-debug project (bower-config-file project) project->bowerrc)
                (println)
-               (bower-debug project (bower-config-file project) project->component))
+               (bower-debug project (bower-package-file project) project->component))
            :else
            (with-json-file
              (bower-package-file project) (project->component project) project


### PR DESCRIPTION
pprint had the wrong labels for the generated files.
