### PR TITLE
Adds Windows support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-bower "0.5.1"
+(defproject lein-bower "0.5.2-SNAPSHOT"
   :description "Manage Bower dependencies for CLJS projects"
   :url "https://github.com/myguidingstar/lein-bower"
   :license {:name "Apache License, version 2.0"

--- a/src/leiningen/bower.clj
+++ b/src/leiningen/bower.clj
@@ -5,7 +5,7 @@
              [with-json-file environmental-consistency transform-deps]]
             [cheshire.core :as json]
             [leiningen.npm.deps :refer [resolve-node-deps]]
-            [leiningen.npm.process :refer [exec]]
+            [leiningen.npm.process :refer [exec iswin]]
             [robert.hooke]
             [leiningen.deps]
             [clojure.java.io :as io]))
@@ -27,7 +27,8 @@
 
 (defn- invoke
   [project & args]
-  (let [local-bower (io/as-file "./node_modules/bower/bin/bower")
+  (let [file-name (if (iswin) "./node_modules/.bin/bower.cmd" "./node_modules/bower/bin/bower")
+        local-bower (io/as-file file-name)
         cmd (if (.exists local-bower) (.getPath local-bower) "bower")]
     (exec (project :root) (cons cmd args))))
 


### PR DESCRIPTION
Use lein-npm's iswin function to determine which bower path to use. On Windows, it defaults to .\bin\bower.cmd.
