### PR TITLE
Regression due to lein-npm; also auto-installing Bower for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ To enable lein-bower for your project, put the following in the
 
 ![Latest version](https://clojars.org/lein-bower/latest-version.svg)
 
+## Linking Bower
+
+lein-bower depends on a real Bower installation on your system.
+
+By default, if no Bower installation is found on first run, lein-bower will automatically install it locally through lein-npm. This can be disabled by setting `:bower {:install-missing-bower false}`.
+
+Alternatively, if you want to associate your project with an external Bower installation, configure `:location` with a path to Bower. This can be either a path to a Bower directory (one that contains `bin/bower`) or a path to the `bower` executable itself.
+
 ## Managing Bower dependencies
 
 Like [NPM](https://github.com/bodil/lein-npm) dependencies,

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :url "https://github.com/myguidingstar/lein-bower"
   :license {:name "Apache License, version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
-  :dependencies [[lein-npm "0.4.0"]]
+  :dependencies [[lein-npm "0.6.1"]]
   :eval-in-leiningen true)

--- a/src/leiningen/bower.clj
+++ b/src/leiningen/bower.clj
@@ -2,7 +2,7 @@
   (:require [leiningen.help :as help]
             [leiningen.core.main :as main]
             [leiningen.npm :refer
-             [with-json-file environmental-consistency transform-deps]]
+             [npm environmental-consistency transform-deps]]
             [cheshire.core :as json]
             [leiningen.npm.deps :refer [resolve-node-deps]]
             [leiningen.npm.process :refer [exec]]
@@ -25,25 +25,88 @@
     :dependencies (transform-deps
                    (resolve-node-deps :bower-dependencies project))}))
 
+(defn- locate-bower-executable
+  [location]
+  (let [file (io/as-file location)]
+    (when (.exists file)
+      (if (.isDirectory file)
+        (let [executable (io/as-file (str location "/bin/bower"))]
+          (when (.exists executable)
+            (.getPath executable)))
+        (.getPath file)))))
+
+(defn- npm-location
+  [project name]
+  (str (get-in project [:npm :root] ".") "/node_modules/" name))
+
+(defn- determine-bower-command
+  [project bower-location install-missing-bower?]
+  (or
+   (and (string? bower-location) (locate-bower-executable bower-location))
+   (and (= bower-location :local) (locate-bower-executable (npm-location project "bower")))
+   (and (= bower-location :local) install-missing-bower?
+        (do
+          (npm project "install" "bower")
+          (locate-bower-executable (npm-location project "bower"))))
+   (and (= bower-location :local) :missing-local-bower)
+   :default))
+
 (defn- invoke
   [project & args]
-  (let [local-bower (io/as-file "./node_modules/bower/bin/bower")
-        cmd (if (.exists local-bower) (.getPath local-bower) "bower")]
-    (exec (project :root) (cons cmd args))))
+  (let [command (determine-bower-command
+                 project
+                 (get-in project [:bower :location] :local)
+                 (get-in project [:bower :install-missing-bower] true))]
+    (if (= command :missing-local-bower)
+      (println "No local Bower module found. Install Bower or configure `:bower :location`.")
+      (do
+        (when (= command :default)
+          (println "Using default command `bower` in PATH..."))
+        (let [cmd (if (= command :default) "bower" command)]
+          (try
+            (exec (project :root) (cons cmd args))
+            (catch java.io.IOException e
+              (println "Failed to execute bower command:")
+              (println "  " cmd)
+              (println "Check your bower installation and its file permissions."))))))))
+
+(defn- root [project]
+  (if-let [root (get-in project [:bower :root])]
+    (if (keyword? root)
+      (project root) ;; e.g. support using :target-path
+      root)
+    (project :root)))
+
+(defn- project-file
+  [filename project]
+  (io/file (root project) filename))
 
 (defn bower-package-file
   [project]
-  (get-in project [:bower :package-file] "bower.json"))
+  (io/file (root project) (get-in project [:bower :package-file] "bower.json")))
 
 (defn bower-config-file
   [project]
-  (get-in project [:bower :config-file] ".bowerrc"))
+  (io/file (root project) (get-in project [:bower :config-file] ".bowerrc")))
+
+(defn- write-ephemeral-file
+  [file content]
+  (doto file
+    (spit content)
+    (.deleteOnExit)))
+
+(defmacro with-ephemeral-file
+  [file content & forms]
+  `(try
+     (write-ephemeral-file ~file ~content)
+     ~@forms
+     (finally (.delete ~file))))
 
 (defn bower-debug
-  [project filename generator]
-  (with-json-file filename (generator project) project
-    (println (str "lein-bower generated " filename ":\n"))
-    (println (slurp filename))))
+  [project file generator]
+  (with-ephemeral-file file (generator project)
+    (println (str "lein-bower generated " file ":\n"))
+    (println (slurp file))))
 
 (defn bower
   "Invoke the Bower component manager."
@@ -58,19 +121,19 @@
                (println)
                (bower-debug project (bower-config-file project) project->bowerrc))
            :else
-           (with-json-file
-             (bower-package-file project) (project->component project) project
-             (with-json-file
-               (bower-config-file project) (project->bowerrc project) project
+           (with-ephemeral-file
+             (bower-package-file project) (project->component project)
+             (with-ephemeral-file
+               (bower-config-file project) (project->bowerrc project)
                (apply invoke project args))))))
 
 (defn install-deps
   [project]
   (environmental-consistency project)
-  (with-json-file
-    (bower-package-file project) (project->component project) project
-    (with-json-file
-      (bower-config-file project) (project->bowerrc project) project
+  (with-ephemeral-file
+    (bower-package-file project) (project->component project)
+    (with-ephemeral-file
+      (bower-config-file project) (project->bowerrc project)
       (invoke project "run-script" "bower"))))
 
 (defn wrap-deps


### PR DESCRIPTION
Changes in lein-npm's API removed `with-json-file` which lein-bower depended on. I've fixed this by duplicating a snippet of code (`with-ephemeral-file`) from lein-npm rather than having them expose their file-handling code as it's sufficiently trivial. Dependency on lein-npm is bumped to 0.6.1.

Also, I've made lein-bower respect lein-npm's `:root` parameter as a local installation could be nested in another directory.

While I was at it, I added a default pathway for lein-bower to automatically install a local Bower (via lein-npm) on first run, so less pre-configuration is required to get started. As a consequence, a couple more configuration options were added (`:install-missing-bower` and `:location`). The invocation flow is a little more forgiving and informative now.